### PR TITLE
SD VANC parsing and portability fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,10 +12,12 @@ AM_SILENT_RULES([yes])
 AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_CXX
+PLAT_PREFIX=Linux
 if test `uname -s` = "Darwin"
 then
 CFLAGS+=" -I/usr/local/include "
-LDFLAGS+=" -L/usr/local/lib "
+LDFLAGS+=" -L/usr/local/lib -framework CoreFoundation"
+PLAT_PREFIX=Mac
 fi
 CFLAGS+=" -DKL_USERSPACE "
 
@@ -62,9 +64,6 @@ AC_TYPE_UINT8_T
 # Checks for library functions.
 AC_CHECK_FUNCS([memset strrchr])
 
-AC_CONFIG_FILES([Makefile tools/Makefile])
-AC_OUTPUT
-
 # Add debug support
 AC_ARG_ENABLE(debug,
   AS_HELP_STRING(
@@ -80,3 +79,24 @@ AM_CONDITIONAL(DEBUG, test x"$debug" = x"true")
 AM_COND_IF(DEBUG,
     AC_DEFINE(DEBUG, 1, [Define to 0 if this is a release build]),
     AC_DEFINE(DEBUG, 0, [Define to 1 or higher if this is a debug build]))
+
+# Path to Blackmagic SDK
+AC_ARG_WITH([bmsdk],
+            [AS_HELP_STRING([--with-bmsdk=path],
+              [specify alternate path to Blackmagic SDK])],
+            [],
+            [with_bmsdk=no])
+
+AS_IF([test "x$with_bmsdk" != xno],
+            [AC_CHECK_FILE([$with_bmsdk/$PLAT_PREFIX/include/DeckLinkAPI.h],
+              [AC_SUBST([BLACKMAGIC_SDK_PATH], [$with_bmsdk/$PLAT_PREFIX/include])
+               AC_DEFINE([HAVE_BMSDK], [1],
+                         [Define if you have BlackMagic SDK installed])
+              ],
+              [AC_MSG_FAILURE(
+                 [--with-bmsdk was given, but SDK not found at specified path])]
+              )],[AC_MSG_WARN([Falling back to Linux SDK which won't work on other platforms]); AC_SUBST([BLACKMAGIC_SDK_PATH], [${ac_pwd}/include/decklink-sdk])])
+
+AC_CONFIG_FILES([Makefile tools/Makefile])
+AC_OUTPUT
+

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -2,8 +2,6 @@
 AUTOMAKE_OPTIONS = foreign
 GIT_VERSION := $(shell git describe --abbrev=8 --dirty --always --tags)
 
-BLACKMAGIC_SDK_PATH = $(top_srcdir)/include/decklink-sdk
-
 AM_CPPFLAGS = -DVERSION=\"$(VERSION)\" -DPROG="\"$(PACKAGE)\"" -D_FILE_OFFSET_BITS=64 \
 	-D_BSD_SOURCE \
 	-I$(BLACKMAGIC_SDK_PATH) \

--- a/tools/capture.cpp
+++ b/tools/capture.cpp
@@ -731,8 +731,16 @@ static void convert_colorspace_and_parse_vanc(unsigned char *buf, unsigned int u
 	uint16_t decoded_words[16384];
 	memset(&decoded_words[0], 0, sizeof(decoded_words));
 	uint16_t *p_anc = decoded_words;
-	if (klvanc_v210_line_to_nv20_c(src, p_anc, sizeof(decoded_words), (uiWidth / 6) * 6) < 0)
-		return;
+	if (uiWidth == 1920) {
+		/* Standard definition video will have VANC spanning both
+		   Luma and Chroma channels */
+		klvanc_v210_line_to_uyvy_c(src, p_anc, uiWidth);
+	} else {
+		if (klvanc_v210_line_to_nv20_c(src, p_anc,
+					       sizeof(decoded_words),
+					       (uiWidth / 6) * 6) < 0)
+			return;
+	}
 
 	/* Don't attempt to parse vanc if we're capturing it and the monitor isn't running. */
 	if (!g_monitor_mode && vancOutputFile >= 0)

--- a/tools/capture.cpp
+++ b/tools/capture.cpp
@@ -629,6 +629,7 @@ static int AnalyzeMuxed(const char *fn)
 	}
 
 	fwr_session_file_close(session);
+	return 0;
 }
 
 static int AnalyzeAudio(const char *fn)


### PR DESCRIPTION
This patch series contains a couple of portability fixes and adds support for proper parsing of VANC packets contained in captures from SD video formats.