### PR TITLE
Fix case where we were using wrong CSC routine on HD video

### DIFF
--- a/tools/capture.cpp
+++ b/tools/capture.cpp
@@ -731,7 +731,8 @@ static void convert_colorspace_and_parse_vanc(unsigned char *buf, unsigned int u
 	uint16_t decoded_words[16384];
 	memset(&decoded_words[0], 0, sizeof(decoded_words));
 	uint16_t *p_anc = decoded_words;
-	if (uiWidth == 1920) {
+
+	if (uiWidth == 720) {
 		/* Standard definition video will have VANC spanning both
 		   Luma and Chroma channels */
 		klvanc_v210_line_to_uyvy_c(src, p_anc, uiWidth);
@@ -824,7 +825,7 @@ static int AnalyzeVANC(const char *fn)
 			}
 			klvanc_smpte2038_packetizer_begin(smpte2038_ctx);
 		}
-		convert_colorspace_and_parse_vanc(buf, uiStride, uiLine);
+		convert_colorspace_and_parse_vanc(buf, uiWidth, uiLine);
 	}
 
 	free(buf);


### PR DESCRIPTION
The caller for file processing was passing the stride instead of
the pixel width, which was inconsistent with how live capture
works.  This caused the wrong CSC to be used for live data display,
as well having entries appear three times since the parser was
overflowing the buffer and reading three times as much data.

Make the file processor pass the width just like live capture,
and fix the check which determines whether the video is HD or SD
to reference the width instead of the stride.