### PR TITLE
Add support for creation of binary files readable by CCExtractor

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -26,6 +26,7 @@ SRC += ts_packetizer.c
 SRC += klringbuffer.c
 SRC += frame-writer.c
 SRC += smpte337_detector.c
+SRC += rcwt.c
 
 #bin_PROGRAMS  = klvanc_util
 bin_PROGRAMS  = klvanc_capture

--- a/tools/capture.cpp
+++ b/tools/capture.cpp
@@ -1809,7 +1809,7 @@ static int _main(int argc, char *argv[])
 			fprintf(stderr, "Could not open rcwt output file \"%s\"\n", g_rcwtOutputFilename);
 			goto bail;
 		}
-		if (rcwt_create_header(rcwtOutputFile, 0xcc, 0x0052) < 0) {
+		if (rcwt_write_header(rcwtOutputFile, 0xcc, 0x0052) < 0) {
 			fprintf(stderr, "Could not write rcwt header to output file\n");
 			goto bail;
 		}

--- a/tools/capture.cpp
+++ b/tools/capture.cpp
@@ -19,6 +19,7 @@
 #include <libklvanc/smpte2038.h>
 #include "smpte337_detector.h"
 #include "frame-writer.h"
+#include "rcwt.h"
 
 #if HAVE_LIBKLMONITORING_KLMONITORING_H
 #include <libklmonitoring/klmonitoring.h>
@@ -126,6 +127,7 @@ static int audioOutputFile = -1;
 static struct fwr_session_s *writeSession = NULL;
 
 static int vancOutputFile = -1;
+static int rcwtOutputFile = -1;
 static int g_showStartupMemory = 0;
 static int g_verbose = 0;
 static unsigned int g_linenr = 0;
@@ -152,6 +154,7 @@ static const char *g_vancOutputFilename = NULL;
 static const char *g_vancInputFilename = NULL;
 static const char *g_muxedOutputFilename = NULL;
 static const char *g_muxedInputFilename = NULL;
+static const char *g_rcwtOutputFilename = NULL;
 static struct fwr_session_s *muxedSession = NULL;
 static int g_maxFrames = -1;
 static int g_shutdown = 0;
@@ -1439,9 +1442,23 @@ static int cb_AFD(void *callback_context, struct klvanc_context_s *ctx, struct k
 
 static int cb_EIA_708B(void *callback_context, struct klvanc_context_s *ctx, struct klvanc_packet_eia_708b_s *pkt)
 {
+	uint8_t caption_data[128];
+
 	/* Have the library display some debug */
 	if (!g_monitor_mode && g_verbose)
 		klvanc_dump_EIA_708B(ctx, pkt);
+
+	if (rcwtOutputFile >= 0) {
+		if (pkt->ccdata.cc_count * 3 > sizeof(caption_data))
+			return -1;
+		for (size_t i = 0; i < pkt->ccdata.cc_count; i++) {
+			caption_data[3*i+0] =  0xf8 | (pkt->ccdata.cc[i].cc_valid ? 0x04 : 0x00) |
+				(pkt->ccdata.cc[i].cc_type & 0x03);
+			caption_data[3*i+1] = pkt->ccdata.cc[i].cc_data[0];
+			caption_data[3*i+2] = pkt->ccdata.cc[i].cc_data[1];
+		}
+		rcwt_write_captions(rcwtOutputFile, pkt->ccdata.cc_count, caption_data, 0);
+	}
 
 	return 0;
 }
@@ -1572,6 +1589,7 @@ static int usage(const char *progname, int status)
 		"                    inspect audio buffers at a byte level. Input should be a file created with -a.\n"
 		"    -V <filename>   raw vanc output filename\n"
 		"    -I <filename>   Interpret and display input VANC filename (See -V)\n"
+		"    -R <filename>   RCWT caption output filename\n"
 		"    -l <linenr>     During -I parse, process a specific line# (def: 0 all)\n"
 		"    -L              List available display modes\n"
 		"    -m <mode>       Eg. Hi59 (1080i59), hp60 (1280x720p60) Hp60 (1080p60) (def: ntsc):\n"
@@ -1660,7 +1678,7 @@ static int _main(int argc, char *argv[])
 	ltn_histogram_alloc_video_defaults(&hist_audio_sfc, "audio sfc");
 	ltn_histogram_alloc_video_defaults(&hist_format_change, "video format change");
 
-	while ((ch = getopt(argc, argv, "?h3c:s:f:a:A:m:n:p:t:vV:I:i:l:LP:MSx:X:")) != -1) {
+	while ((ch = getopt(argc, argv, "?h3c:s:f:a:A:m:n:p:t:vV:I:i:l:LP:MSx:X:R:")) != -1) {
 		switch (ch) {
 #if HAVE_LIBKLMONITORING_KLMONITORING_H
 		case 'S':
@@ -1721,6 +1739,9 @@ static int _main(int argc, char *argv[])
 		case 'V':
 			g_vancOutputFilename = optarg;
 			break;
+		case 'R':
+			g_rcwtOutputFilename = optarg;
+			break;
 		case 'n':
 			g_maxFrames = atoi(optarg);
 			break;
@@ -1780,6 +1801,18 @@ static int _main(int argc, char *argv[])
 	if (wantHelp) {
 		usage(argv[0], 0);
 		goto bail;
+	}
+
+	if (g_rcwtOutputFilename != NULL) {
+		rcwtOutputFile = open(g_rcwtOutputFilename, O_WRONLY | O_CREAT | O_TRUNC, 0664);
+		if (rcwtOutputFile < 0) {
+			fprintf(stderr, "Could not open rcwt output file \"%s\"\n", g_rcwtOutputFilename);
+			goto bail;
+		}
+		if (rcwt_create_header(rcwtOutputFile, 0xcc, 0x0052) < 0) {
+			fprintf(stderr, "Could not write rcwt header to output file\n");
+			goto bail;
+		}
 	}
 
  	if (g_packetizeSMPTE2038) {
@@ -1955,6 +1988,8 @@ bail:
 		fwr_session_file_close(muxedSession);
 	if (vancOutputFile)
 		close(vancOutputFile);
+	if (rcwtOutputFile)
+		close(rcwtOutputFile);
 
 	RELEASE_IF_NOT_NULL(displayModeIterator);
 	RELEASE_IF_NOT_NULL(deckLinkInput);

--- a/tools/rcwt.c
+++ b/tools/rcwt.c
@@ -1,0 +1,67 @@
+/* Copyright (c) 2018 Kernel Labs Inc. All Rights Reserved. */
+
+#include "rcwt.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+int rcwt_create_header(int fd, uint8_t creating_program, uint16_t program_version)
+{
+	char header[11];
+	ssize_t ret;
+
+	/* Magic number */
+	header[0] = 0xcc;
+	header[1] = 0xcc;
+	header[2] = 0xed;
+
+	/* Creating Program */
+	header[3] = creating_program;
+
+	/* Program version number */
+	header[4] = program_version >> 8;
+	header[5] = program_version & 0xff;
+
+	/* File format version */
+	header[6] = 0x00;
+	header[7] = 0x01;
+	/* Reserved */
+	header[8] = 0x00;
+	header[9] = 0x00;
+	header[10] = 0x00;
+	ret = write(fd, header, sizeof(header));
+	if (ret != sizeof(header))
+		return -1;
+	return 0;
+}
+
+int rcwt_write_captions(int fd, uint16_t cc_count, uint8_t *caption_data, uint64_t caption_time)
+{
+	int ret;
+	uint8_t group_header[10];
+
+	/* Specification doesn't explicitly indicate Endianness,
+	   but CCExtractor doesn't make any effort to do byte order
+	   conversion and Intel is the most common platform */
+	group_header[0] = caption_time       & 0xff;
+	group_header[1] = caption_time >>  8 & 0xff;
+	group_header[2] = caption_time >> 16 & 0xff;
+	group_header[3] = caption_time >> 24 & 0xff;
+	group_header[4] = caption_time >> 32 & 0xff;
+	group_header[5] = caption_time >> 40 & 0xff;
+	group_header[6] = caption_time >> 48 & 0xff;
+	group_header[7] = caption_time >> 56 & 0xff;
+
+	group_header[8] = cc_count      & 0xff;
+	group_header[9] = cc_count >> 8 & 0xff;
+
+	/* FIXME: endianness for caption_time/FTS values? */
+	ret = write(fd, group_header, sizeof(group_header));
+	if (ret != sizeof(group_header))
+		return -1;
+	ret = write(fd, caption_data, cc_count * 3);
+	if (ret != sizeof(cc_count * 3))
+		return -1;
+
+	return 0;
+}

--- a/tools/rcwt.c
+++ b/tools/rcwt.c
@@ -5,7 +5,7 @@
 #include <unistd.h>
 #include <string.h>
 
-int rcwt_create_header(int fd, uint8_t creating_program, uint16_t program_version)
+int rcwt_write_header(int fd, uint8_t creating_program, uint16_t program_version)
 {
 	char header[11];
 	ssize_t ret;

--- a/tools/rcwt.h
+++ b/tools/rcwt.h
@@ -41,7 +41,7 @@
 extern "C" {
 #endif
 
-int rcwt_create_header(int fd, uint8_t creating_program, uint16_t program_version);
+int rcwt_write_header(int fd, uint8_t creating_program, uint16_t program_version);
 int rcwt_write_captions(int fd, uint16_t cc_count, uint8_t *caption_data, uint64_t caption_time);
 
 #ifdef __cplusplus

--- a/tools/rcwt.h
+++ b/tools/rcwt.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 Kernel Labs Inc. All Rights Reserved
+ *
+ * Address: Kernel Labs Inc., PO Box 745, St James, NY. 11780
+ * Contact: sales@kernellabs.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file	rcwt.h
+ * @author	Devin Heitmueller <dheitmueller@kernellabs.com>
+ * @copyright	Copyright (c) 2018 Kernel Labs Inc. All Rights Reserved.
+ * @brief	Helper functions to create files readable by CCExtractor
+ */
+
+/* Raw Captions With Time (RCWT).  Defined as the binary file format
+ * of CCExtractor, starting in version 0.52.  The full text of the
+ * specification can be found in the CCExtractor source tarball in
+ * the file named docs/BINARY_FILE_FORMAT.TXT
+ */
+
+#ifndef RCWT_H
+#define RCWT_H
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int rcwt_create_header(int fd, uint8_t creating_program, uint16_t program_version);
+int rcwt_write_captions(int fd, uint16_t cc_count, uint8_t *caption_data, uint64_t caption_time);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* RWCT_H */


### PR DESCRIPTION
Add functionality to klvanc_capture to generate files in
CCExtractor's native binary format (called RCWT).  This allows us
to take SDI captures from the field containing CEA-708 CDP payloads
and use ccextractor's tools against them.

Example usage:
./klvanc_capture -I vanc.raw -R captions.bin
ccextractor -txt -stdout captions.bin