### PR TITLE
klvanc_transmitter fixes

### DIFF
--- a/tools/capture.cpp
+++ b/tools/capture.cpp
@@ -1111,7 +1111,7 @@ static void ProcessVANC(IDeckLinkVideoInputFrame * frame)
 		}
 	}
 
-	if (g_verbose) {
+	if (g_verbose > 1) {
 		fprintf(stdout, "PixelFormat %x [%s] DisplayMode [%s] Wrote %d [potential] VANC lines\n",
 			pf,
 			pf == bmdFormat8BitYUV ? "bmdFormat8BitYUV" :
@@ -1431,7 +1431,7 @@ HRESULT DeckLinkCaptureDelegate::VideoInputFrameArrived(IDeckLinkVideoInputFrame
 			if (frameTime->remoteFrameCount + 1 == currRFC)
 				isBad = 0;
 
-			if (g_verbose) {
+			if (g_verbose > 1) {
 				fprintf(stdout,
 					"Frame received (#%10llu) [%s] - %s - Size: %li bytes (%7.2f ms) [remoteFrame: %d] ",
 					frameTime->frameCount,
@@ -1511,7 +1511,7 @@ HRESULT DeckLinkCaptureDelegate::VideoInputFrameArrived(IDeckLinkVideoInputFrame
 		double interval = t - frameTime->lastTime;
 		interval /= 10;
 
-		if (g_verbose) {
+		if (g_verbose > 1) {
 			fprintf(stdout,
 				"Audio received (#%10lu) - Size: %u sfc: %lu channels: %u depth: %u bytes  (%7.2f ms)\n",
 				audioFrameCount,

--- a/tools/db.cpp
+++ b/tools/db.cpp
@@ -89,8 +89,6 @@ int ltn_db_load(const char *cfgfile)
 
 		/* Load arbitrary data, re-align length for V210 and into something the blackmagic SDK wants to playout. */
 		size_t l = fread(&db[ltn_db_count].payload[0], 2, 1024, fh);
-		l += 24;
-		l = ((l + 5) / 6) * 6; /* align for v210 */
 		db[ltn_db_count].payloadWords = l;
 
 		fclose(fh);


### PR DESCRIPTION
This patch series contains a change to properly support file payloads which aren't v210 aligned.  Also included is a tweak so that with "-v" it shows decoded VANC payloads only and not the continuous "audio/frame received" messages (those have been demoted to "-vv")