### PR TITLE
Add support for burning KL frame counters into video as well

### DIFF
--- a/tools/Config.cpp
+++ b/tools/Config.cpp
@@ -368,7 +368,7 @@ bail:
 		"    -c <channels>        Audio Channels (2, 8 or 16 - default is 2)\n"
 		"    -s <depth>           Audio Sample Depth (16 or 32 - default is 16)\n"
 		"    -M <cfgfile>         Enter VANC message injection menus, using a specific vanc configuration\n"
-		"    -k                   Inject KL frame counters into VANC on line 14\n"
+		"    -k                   Inject KL frame counters into video and VANC on line 14\n"
 		"\n"
 		"Output a test pattern and start the interactive VANC transmitter UI:\n"
 		"\n"

--- a/tools/transmitter.cpp
+++ b/tools/transmitter.cpp
@@ -612,6 +612,8 @@ void TestPattern::ScheduleNextFrame(bool prerolling)
 		if (vanc->GetBufferForVerticalBlankingLine(14, (void**)&vancBuf) == S_OK)
 			memcpy(vancBuf, dst, dstCount);
 		free(pkt);
+
+		V210_write_32bit_value(dstFramePtr, (m_frameWidth * bytesPerPixel), m_frame_num, 1, 0);
 	}
 
 	if (newFrame->SetAncillaryData(vanc) != S_OK) {

--- a/tools/v210burn.c
+++ b/tools/v210burn.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include "font8x8_basic.h"
 
+#define V210_BOX_HEIGHT 30 /* must be a multiple of six (represents pixel width of each box drawn ) */
+
 static void compute_colorbar_10bit_array(const uint32_t uyvy, uint8_t *bar10)
 {
 	uint8_t *bar8 = (uint8_t *)&uyvy;
@@ -114,4 +116,93 @@ int v210_burn(unsigned char *frame, unsigned int width, unsigned int height,
 		v210_burn_char(frame, stride, *(s + i), x + i, y);
 
 	return 0;
+}
+
+#define  y_white 0x3ff
+#define  y_black 0x000
+#define cr_white 0x200
+#define cb_white 0x200
+
+/* Six pixels */
+uint32_t V210_white[] = {
+	 cr_white << 20 |  y_white << 10 | cb_white,
+	  y_white << 20 | cb_white << 10 |  y_white,
+	 cb_white << 20 |  y_white << 10 | cr_white,
+	  y_white << 20 | cr_white << 10 |  y_white,
+};
+
+uint32_t V210_black[] = {
+	 cr_white << 20 |  y_black << 10 | cb_white,
+	  y_black << 20 | cb_white << 10 |  y_black,
+	 cb_white << 20 |  y_black << 10 | cr_white,
+	  y_black << 20 | cr_white << 10 |  y_black,
+};
+
+
+/* KL paint 6 pixels in a single point */
+__inline__ void V210_draw_6_pixels(uint32_t *addr, uint32_t *coloring)
+{
+	for (int i = 0; i < (V210_BOX_HEIGHT / 6); i++) {
+		addr[0] = coloring[0];
+		addr[1] = coloring[1];
+		addr[2] = coloring[2];
+		addr[3] = coloring[3];
+		addr += 4;
+	}
+}
+
+void V210_draw_box(uint32_t *frame_addr, uint32_t stride, int color, int interlaced)
+{
+	uint32_t *coloring;
+	if (color == 1)
+		coloring = V210_white;
+	else
+		coloring = V210_black;
+
+	int interleaved = interlaced ? 2 : 1;
+	interleaved = 1;
+	for (uint32_t l = 0; l < V210_BOX_HEIGHT; l++) {
+		uint32_t *addr = frame_addr + ((l * interleaved) * (stride / 4));
+		V210_draw_6_pixels(addr, coloring);
+	}
+}
+
+__inline__ void V210_draw_box_at(uint32_t *frame_addr, uint32_t stride, int color, int x, int y, int interlaced)
+{
+	uint32_t *addr = frame_addr + (y * (stride / 4));
+	addr += ((x / 6) * 4);
+	V210_draw_box(addr, stride, color, interlaced);
+}
+
+void V210_write_32bit_value(void *frame_bytes, uint32_t stride, uint32_t value, uint32_t lineNr, int interlaced)
+{
+	for (int p = 31, sh = 0; p >= 0; p--, sh++) {
+		V210_draw_box_at(((uint32_t *)frame_bytes), stride,
+			(value & (1 << sh)) == (uint32_t)(1 << sh), p * V210_BOX_HEIGHT, lineNr, interlaced);
+	}
+}
+
+uint32_t V210_read_32bit_value(void *frame_bytes, uint32_t stride, uint32_t lineNr, double scalefactor)
+{
+	double pixheight = V210_BOX_HEIGHT * scalefactor;
+	double newlinenr = lineNr * scalefactor;
+
+	int xpos = 0;
+	uint32_t bits = 0;
+	for (int i = 0; i < 32; i++) {
+		xpos = (i * pixheight) + (pixheight / 2);
+		/* Sample the pixel two lines deeper than the initial line, and eight pixels in from the left */
+		uint32_t *addr = ((uint32_t *)frame_bytes) + (((int)newlinenr + 2) * (stride / 4));
+		addr += ((xpos / 6) * 4);
+
+		bits <<= 1;
+
+		/* Sample the pixel.... Compressor will decimate, we'll need a luma threshold for production. */
+		if ((addr[1] & 0x3ff) > 0x080)
+			bits |= 1;
+	}
+#if LOCAL_DEBUG
+	printf("%s(%p) = 0x%08x\n", __func__, frame_bytes, bits);
+#endif
+	return bits;
 }

--- a/tools/v210burn.h
+++ b/tools/v210burn.h
@@ -10,6 +10,9 @@ extern "C" {
 int v210_burn(unsigned char *frame, unsigned int width, unsigned int height,
 	      unsigned int stride, const char *s, unsigned int x, unsigned int y);
 
+void V210_write_32bit_value(void *frame_bytes, uint32_t stride, uint32_t value, uint32_t lineNr, int interlaced);
+uint32_t V210_read_32bit_value(void *frame_bytes, uint32_t stride, uint32_t lineNr, double scalefactor);
+
 #ifdef __cplusplus
 };
 #endif


### PR DESCRIPTION
In addition to inserting KL frame counters into VANC, also burn them into the video in a manner parseable by the burnreader.  This allows klvanc_capture to check the synchrnonization between video and VANC.

When specifying the "-k" option for klvanc_capture in curses mode, an extra line will be inserted into the GUI which shows how far out of sync the video and VANC are.